### PR TITLE
Move os to io handler

### DIFF
--- a/foolscap/handle_note_io.py
+++ b/foolscap/handle_note_io.py
@@ -31,6 +31,8 @@ def load_text(path, new_note=False):
 
 
 def edit_text(editing=None):
+    """ Opens editor with path 'editing' else opens temp file
+    """
     # Maybe this can be split into two functions in subprocess_utils
     if not editing:
         with NamedTemporaryFile(mode='r+', suffix='.tmp') as editing_text:
@@ -45,6 +47,14 @@ def edit_text(editing=None):
 def replace_text(note, new_name, content):
     remove_text(note)
     save_text(new_name, content)
+
+
+def move_text_to_bin(note):
+    delete_note = NOTE_FOLDERS['GET_NOTE'].format(note_name=note)
+
+    bin_note = unique_text(note, folder='IN_BIN')
+    bin_path = NOTE_FOLDERS['BIN_NOTE'].format(note_name=bin_note)
+    os.rename(delete_note, bin_path)
 
 
 def save_text(note_title, content):

--- a/foolscap/note_content.py
+++ b/foolscap/note_content.py
@@ -1,11 +1,8 @@
-import os
-
 from foolscap.file_paths import NOTE_FOLDERS
-from foolscap.handle_note_io import (
-    load_text,
-    edit_text,
-    unique_text,
-)
+
+from foolscap.handle_note_io import load_text
+from foolscap.handle_note_io import edit_text
+from foolscap.handle_note_io import move_text_to_bin
 
 from foolscap.meta_data import (
     shift_lines,
@@ -68,13 +65,7 @@ def delete_note(note):
     """ Delete a note stored in foolscap
     """
     if note_exists(note):
-        folders = NOTE_FOLDERS
-        delete_file = folders['GET_NOTE'].format(note_name=note)
-
-        recycle_bin = unique_text(note, folder='IN_BIN')
-        bin_note = folders['BIN_NOTE'].format(note_name=recycle_bin)
-
-        os.rename(delete_file, bin_note)
+        move_text_to_bin(note)
         remove_component(note)
         print("\n\tDeleted: '{}'.\n".format(note))
 

--- a/tests/test_note_content.py
+++ b/tests/test_note_content.py
@@ -22,12 +22,12 @@ def test_view_note():
 
 def test_delete_note():
     with patch('foolscap.note_content.note_exists') as exists,\
-         patch('foolscap.note_content.os'),\
-         patch('foolscap.note_content.unique_text', side_effect='note_test'),\
+         patch('foolscap.note_content.move_text_to_bin') as move_bin,\
          patch('foolscap.note_content.remove_component') as mock_remove:
         exists.return_value = True
         note_content.delete_note('test_note')
         exists.assert_called_once_with('test_note')
+        move_bin.assert_called_once_with('test_note')
         mock_remove.assert_called_once_with('test_note')
 
 


### PR DESCRIPTION
    This separates foolscap functionality from
    implementation.

    note_content no longer relies on importing os