### PR TITLE
Implement search for notes starting with query

### DIFF
--- a/foolscap/actor.py
+++ b/foolscap/actor.py
@@ -1,4 +1,5 @@
 from foolscap.note_display import list_notes
+from foolscap.note_display import search_notes
 from foolscap.note_content import (
     save_note,
     view_note,
@@ -16,6 +17,7 @@ FUNCTION_MAP = {
     'save': save_note,
     'view': view_note,
     'list': list_notes,
+    'search': search_notes,
     'delete': delete_note,
     'edit': edit_note,
     'new': new_note,
@@ -25,11 +27,17 @@ FUNCTION_MAP = {
 }
 
 
+DISPLAY_ACTIONS = [
+    'list',
+    'search',
+]
+
+
 def action(do_action, arg, list_type='normal'):
     func = FUNCTION_MAP[do_action]
 
     new_action = None
-    if do_action == 'list':
+    if do_action in DISPLAY_ACTIONS:
         # Quitting from list calls exit() method.
         # arg is filter in this case
         if arg:

--- a/foolscap/cli.py
+++ b/foolscap/cli.py
@@ -7,6 +7,7 @@ FEATURES = [
     'save',
     'view',
     'list',
+    'search',
     'delete',
     'edit',
     'new',

--- a/foolscap/note_display.py
+++ b/foolscap/note_display.py
@@ -51,6 +51,24 @@ def list_notes(tag, list_type='normal'):
     return display_list(display_notes)
 
 
+def search_notes(query, list_type='normal'):
+    if query:
+        all_notes = load_meta()
+        found_notes = query_notes(query, all_notes)
+        display_notes = display_information(found_notes, all_notes)
+        if display_notes:
+            return display_list(display_notes)
+        print("\n\tNo Note Found with '{}'.\n".format(query))
+        exit()
+    print("\n\tNo Query Error!\n")
+    exit()
+
+
+def query_notes(query, all_notes):
+    notes = [key for key, value in all_notes.items() if key.startswith(query)]
+    return alphabetise(notes)
+
+
 def count_tags(all_notes):
     list_tags = []
     for key, values in all_notes.items():
@@ -146,6 +164,10 @@ def pull_top_viewed(note_dict):
     ]
 
 
+def alphabetise(notes):
+    return sorted(notes, key=lambda x: x.lower())
+
+
 def sort_notes(note_data):
     """ Custom sort to display notes.
 
@@ -165,12 +187,11 @@ def sort_notes(note_data):
         organised_notes.insert(0, last_opened)
         data_copy.pop(last_opened)
 
-    remaining_notes = list(data_copy)
-    alphabetise = sorted(remaining_notes, key=lambda x: x.lower())
+    remaining_notes = alphabetise(list(data_copy))
 
     return [
         note_title
-        for note_title in organised_notes + alphabetise
+        for note_title in organised_notes + remaining_notes
         if note_title is not None
     ]
 

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -2,6 +2,8 @@ from mock import call
 from mock import patch
 from mock import MagicMock
 
+import pytest
+
 from foolscap import actor
 
 
@@ -46,6 +48,25 @@ def test_export_note_command():
         actor.action('export', 'mock_note')
         mock_action.assert_called_once()
         assert mock_action.call_args == expected
+
+
+@pytest.mark.parametrize("query, expected",
+    # Test with Query = 'te'
+    [('te', [call('te', 'normal'), call('te')]),
+
+    # Test without query
+     (None, [call(None, 'normal'), call()]),
+    ])
+def test_search_note(query, expected):
+    TESTED_ACTIONS.append('search')
+    mock_action = MagicMock()
+    with  patch.dict('foolscap.actor.FUNCTION_MAP', {'search': mock_action}):
+        mock_action.return_value = None
+        expected = expected
+
+        # Pass to actor:
+        actor.action('search', query)
+        assert mock_action.call_args_list == expected
 
 
 def test_list_note_command_no_tags():

--- a/tests/test_note_display.py
+++ b/tests/test_note_display.py
@@ -11,14 +11,14 @@ from data.mock_meta_data import FOUR_FAKE_NOTES
 
 
 # Little reminder on how to use parametrize:
-@pytest.mark.parametrize("expected",[1,2])
+@pytest.mark.parametrize("expected", [1, 2])
 def test_param(expected):
     assert expected / 3 < 1
 
 
-@pytest.mark.parametrize("inp,expected",
-    [(1,2),
-     (2,4)])
+@pytest.mark.parametrize("inp, expected",
+    [(1, 2),
+     (2, 4)])
 def test_param(inp, expected):
     result = inp * 2
     assert result == expected
@@ -191,3 +191,50 @@ def test_create_tag_display():
                       ('third_most', 'This is a fake note'),
                       ('Z', 'This is a fake note')]}]
 
+
+def test_search_notes_with_no_query():
+    with pytest.raises(SystemExit):
+        note_display.search_notes(None)
+
+
+def test_search_notes():
+    test_dict = FAKE_MANY_NOTES.copy()
+    expected = [{'title': 'most_viewed',
+                 'description': 'This is a fake note'}]
+    def fake_return(input_param):
+        return input_param
+
+    with patch('foolscap.note_display.display_list') as mock_display,\
+         patch('foolscap.note_display.load_meta') as mock_meta:
+        mock_meta.return_value = test_dict
+        mock_display.side_effect = fake_return
+        result = note_display.search_notes('most')
+        assert result == expected
+
+
+def test_search_notes_with_no_results():
+    test_dict = FAKE_MANY_NOTES.copy()
+    expected = [{'title': 'most_viewed',
+                 'description': 'This is a fake note'}]
+    def fake_return(input_param):
+        return input_param
+
+    with patch('foolscap.note_display.display_list') as mock_display,\
+         patch('foolscap.note_display.load_meta') as mock_meta,\
+         pytest.raises(SystemExit):
+        mock_meta.return_value = test_dict
+        mock_display.side_effect = fake_return
+        result = note_display.search_notes('none')
+        assert result == expected
+
+
+def test_query_notes():
+    all_notes = {'this' : 1, 'that': 2, 'make': 3}
+    result = note_display.query_notes('th', all_notes)
+    assert result == ['that', 'this']
+
+
+def test_alphabetise():
+    notes = ['bee', 'AYE', 'cee', 'aei']
+    result = note_display.alphabetise(notes)
+    assert result == ['aei', 'AYE', 'bee', 'cee']


### PR DESCRIPTION
The command line can now do a search for notes that start with the query.
e.g.
```
$ fscap search py
```
Will list all notes starting with `py`